### PR TITLE
Fix missing email validator dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Install dependencies:
 pip install -r backend/requirements.txt
 ```
 
+This installs FastAPI along with `email-validator`, which is required for Pydantic's `EmailStr` type used in the API models.
+
 Start the server:
 
 ```bash

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ sqlalchemy
 psycopg2-binary
 passlib[bcrypt]
 python-jose[cryptography]
+email-validator


### PR DESCRIPTION
## Summary
- add `email-validator` to backend requirements
- mention `email-validator` in README

## Testing
- `pip install -r backend/requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6852c2e4d6a48331ac8bbfb49cb99349