### PR TITLE
Add basic home dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains a simple iOS Swift package and a Python backend for a family planner application.
 
 ## iOS App
-The Swift package in this repo is a minimal starting point for a future iOS app. You can build it with `swift build`.
+The Swift package in this repo is a minimal starting point for a future iOS app. After logging in, the app now presents a basic home dashboard with placeholder widgets for a calendar and a task list. You can build it with `swift build`.
 
 ## Backend
 The Python backend uses FastAPI and connects to a Postgres database hosted on Render.com.

--- a/Sources/FamilyPlannerApp.swift
+++ b/Sources/FamilyPlannerApp.swift
@@ -39,11 +39,55 @@ struct LoggedInView: View {
     let logoutAction: () -> Void
 
     var body: some View {
-        VStack {
-            Text("Logged in")
-            Button("Logout", action: logoutAction)
+        DashboardView(logoutAction: logoutAction)
+    }
+}
+
+struct DashboardView: View {
+    let logoutAction: () -> Void
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(spacing: 20) {
+                    CalendarWidget()
+                    TaskListWidget()
+                }
+                .padding()
+            }
+            .navigationTitle("Home")
+            .toolbar {
+                Button("Logout", action: logoutAction)
+            }
         }
-        .padding()
+    }
+}
+
+struct CalendarWidget: View {
+    var body: some View {
+        GroupBox(label: Label("Calendar", systemImage: "calendar")) {
+            Rectangle()
+                .fill(Color.gray.opacity(0.2))
+                .frame(height: 200)
+                .overlay(
+                    Text("Calendar coming soon")
+                        .foregroundColor(.secondary)
+                )
+        }
+    }
+}
+
+struct TaskListWidget: View {
+    var body: some View {
+        GroupBox(label: Label("Tasks", systemImage: "checklist")) {
+            Rectangle()
+                .fill(Color.gray.opacity(0.2))
+                .frame(height: 200)
+                .overlay(
+                    Text("Task list coming soon")
+                        .foregroundColor(.secondary)
+                )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add a dashboard view shown after login
- display placeholder calendar and task list widgets
- mention dashboard in the README

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_685aaab4145883318359def433d8c05c