### PR TITLE
Disable autocorrect for SwiftUI inputs

### DIFF
--- a/Sources/FamilyPlannerApp.swift
+++ b/Sources/FamilyPlannerApp.swift
@@ -111,15 +111,21 @@ struct AuthView: View {
 
             if !isLogin {
                 TextField("Username", text: $username)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
                     .textFieldStyle(.roundedBorder)
                     .padding([.horizontal])
             }
 
             TextField("Email", text: $email)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled(true)
                 .textFieldStyle(.roundedBorder)
                 .padding([.horizontal])
 
             SecureField("Password", text: $password)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled(true)
                 .textFieldStyle(.roundedBorder)
                 .padding([.horizontal])
 


### PR DESCRIPTION
## Summary
- disable autocapitalization and autocorrection for login fields

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*
- `python3 -m py_compile $(find backend -name '*.py' -print)`

------
https://chatgpt.com/codex/tasks/task_e_685aae1ce7ec8331a3c0a08cdf0e775d